### PR TITLE
Set `schedule = "dirty"` for the rust's `compress`/`decompress` functions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nif: ["2.16", "2.15"]
+        nif: ["2.17", "2.16", "2.15"]
         job:
           - {
               target: arm-unknown-linux-gnueabihf,

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.2.2
-elixir 1.16.1
+erlang 27.2.4
+elixir 1.18.2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wrapper around [rust-brotli](https://github.com/dropbox/rust-brotli)
 ```elixir
 def deps do
   [
-    {:ex_brotli, "~> 0.1.0"}
+    {:ex_brotli, "~> 0.5.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wrapper around [rust-brotli](https://github.com/dropbox/rust-brotli)
 ```elixir
 def deps do
   [
-    {:ex_brotli, "~> 0.5.0"}
+    {:ex_brotli, "~> 0.6.0"}
   ]
 end
 ```
@@ -26,7 +26,7 @@ plug Plug.Static,
  ...
  brotli: true
  ```
- 
+
 Then tell Phoenix to also compress with Brotli.
 
 ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExBrotli.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.6.0"
   @source_url "https://github.com/mfeckie/ex_brotli"
 
   def project do

--- a/native/ex_brotli/Cargo.lock
+++ b/native/ex_brotli/Cargo.lock
@@ -103,7 +103,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "rustler"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04a7b61bf2db5495d6c0d2eb4b3f0f366864d47f2482834656e25d1b25fe290"
 dependencies = [
  "inventory",
  "libloading",
@@ -113,7 +115,9 @@ dependencies = [
 
 [[package]]
 name = "rustler_codegen"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9365a04e3a3a4d3136953d97c67fd0a9c036d36197917961551c2cc1ecb385"
 dependencies = [
  "heck",
  "inventory",

--- a/native/ex_brotli/Cargo.lock
+++ b/native/ex_brotli/Cargo.lock
@@ -103,9 +103,7 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "rustler"
-version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7b219d7473cf473409665a4898d66688b34736e51bb5791098b0d3390e4c98"
 dependencies = [
  "inventory",
  "libloading",
@@ -115,9 +113,7 @@ dependencies = [
 
 [[package]]
 name = "rustler_codegen"
-version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743ec5267bd5f18fd88d89f7e729c0f43b97d9c2539959915fa1f234300bb621"
 dependencies = [
  "heck",
  "inventory",

--- a/native/ex_brotli/Cargo.lock
+++ b/native/ex_brotli/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ex_brotli"
-version = "0.3.1"
+version = "0.6.0"
 dependencies = [
  "brotli",
  "rustler",

--- a/native/ex_brotli/Cargo.toml
+++ b/native/ex_brotli/Cargo.toml
@@ -11,4 +11,3 @@
 
 [dependencies]
   brotli = "7.0.0"
-  rustler = "0.36.0"

--- a/native/ex_brotli/Cargo.toml
+++ b/native/ex_brotli/Cargo.toml
@@ -11,3 +11,4 @@
 
 [dependencies]
   brotli = "7.0.0"
+  rustler = "0.36.1"

--- a/native/ex_brotli/Cargo.toml
+++ b/native/ex_brotli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name = "ex_brotli"
-  version = "0.3.1"
+  version = "0.6.0"
   authors = []
   edition = "2021"
 

--- a/native/ex_brotli/src/lib.rs
+++ b/native/ex_brotli/src/lib.rs
@@ -3,7 +3,7 @@ use brotli::CompressorReader;
 use rustler::{Binary, Encoder, Env, NifResult, OwnedBinary, Term};
 use std::io::{Read, Write};
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn compress<'a>(env: Env<'a>, input: Binary) -> NifResult<Term<'a>> {
     let mut compressor = CompressorReader::new(input.as_slice(), 4096, 11, 22);
 
@@ -19,7 +19,7 @@ fn compress<'a>(env: Env<'a>, input: Binary) -> NifResult<Term<'a>> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn decompress<'a>(env: Env<'a>, input: Binary) -> NifResult<Term<'a>> {
     let mut decompressor = brotli::Decompressor::new(input.as_slice(), 4096);
 


### PR DESCRIPTION
Given compressing a big file in brotli can take quite some time, the rust `compress`/`decompress` functions blocks the Erlang regular schedulers leading to other erlang processes not being scheduled properly anymore.

For the current use case, given it's pure CPU (the NIF don't work with files, though it could be a nice improvement) then marking them with the `#[rustler::nif(schedule = "DirtyCpu")]` allows the erlang VM to run them on the "dirty scheduler".

For my use-case, I run the compression on multiple files (some larger than other, up to 100MB) in `Task`s with updates sent to a Phoenix `LiveView`.

Before those changes, the `LiveView` process is blocked (as well as any other requests) leading to disconnection until the compression is finished.

After those changes, everything runs properly at all time.

I split the changes in multiple commits, so if you want to accept only some of them, feel free to tell me and I'll make separate PR.
